### PR TITLE
Simplify check set parameters in acmedns config

### DIFF
--- a/acmedns-hook.sh
+++ b/acmedns-hook.sh
@@ -22,13 +22,13 @@ deploy_challenge() {
       DOMAIN="${DOMAIN:2}"
     fi
 
-    if [[ -v ACMEDNS_USERNAME[@] ]] && [[ "${ACMEDNS_USERNAME["$DOMAIN"]+isset}" ]]; then
+    if [[ "${ACMEDNS_USERNAME["$DOMAIN"]+isset}" ]]; then
       _ACMEDNS_USERNAME=${ACMEDNS_USERNAME["$DOMAIN"]}
     fi
-    if [[ -v ACMEDNS_PASSWORD[@] ]] && [[ "${ACMEDNS_PASSWORD["$DOMAIN"]+isset}" ]]; then
+    if [[ "${ACMEDNS_PASSWORD["$DOMAIN"]+isset}" ]]; then
       _ACMEDNS_PASSWORD=${ACMEDNS_PASSWORD["$DOMAIN"]}
     fi
-    if [[ -v ACMEDNS_SUBDOMAIN[@] ]] && [[ "${ACMEDNS_SUBDOMAIN["$DOMAIN"]+isset}" ]]; then
+    if [[ "${ACMEDNS_SUBDOMAIN["$DOMAIN"]+isset}" ]]; then
       _ACMEDNS_SUBDOMAIN=${ACMEDNS_SUBDOMAIN["$DOMAIN"]}
     fi
 


### PR DESCRIPTION
Bash 5.2 contains the following change (from their NEWS section):

> j. Associative array assignment and certain instances of referencing (e.g.,
>   `test -v' now allow `@' and `*' to be used as keys.

… which breaks the existing check. Simply reference check for a set array item directly.